### PR TITLE
Dynamic Allocation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,53 @@ print(sco)
 # spark.sql.shuffle.partitions: 600
 ```
 
+### Dynamic Allocation
+
+For Spark dynamic allocation mode, you can calculate with `dynamic_allocation` is set `True` (default `False`).
+
+#### Not specify num_nodes
+
+When `dynamic_allocation` is `True` and `num_nodes` is `None`, optimizer returns only Spark properties about resources (Not contains about parallelism like `spark.default.parallelism`).
+
+```python
+sco = SparkConfOptimizer(
+    executor_instance,
+    deploy_model=deploy_mode,
+    dynamic_allocation=True,
+)
+print(sco)
+
+# spark.driver.cores: 3
+# spark.driver.memory: 26g
+# spark.driver.memoryOvearhead: 3g
+# spark.executor.cores: 5
+# spark.executor.memory: 36g
+# spark.executor.memoryOvearhead: 5g
+```
+
+#### Specify num_nodes
+
+If `dynamic_allocation` set `True` (default `False`) and specify `num_nodes`, optimizer returns `spark.default.parallelism` and `spark.sql.shuffle.partitions` for when executor nodes reach to num_nodes, but does not return `spark.executor.instances`.
+
+```python
+sco = SparkConfOptimizer(
+    executor_instance,
+    num_nodes,
+    deploy_model=deploy_mode,
+    dynamic_allocation=True,
+)
+print(sco)
+
+# spark.driver.cores: 3
+# spark.driver.memory: 26g
+# spark.driver.memoryOvearhead: 3g
+# spark.executor.cores: 5
+# spark.executor.memory: 36g
+# spark.executor.memoryOvearhead: 5g
+# spark.default.parallelism: 600
+# spark.sql.shuffle.partitions: 600
+```
+
 ### Predefined Instance
 
 You can use predefined `Instance` class.


### PR DESCRIPTION
Add `dynamic_allocation` option to optimizer.
When `spark.dynamicAllocation.enabled` is True, properties about parallelism (like `spark.executor.instances`) is unnecessary.
So by introducing `dynamic_allocation`, it is can be turn on/off parallelism properties.
